### PR TITLE
Change route object in ContextStore

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,24 @@
 import React from 'react/addons';
+import dispatcher from './dispatcher/StorefrontDispatcher';
 
 class App extends React.Component {
+  triggerRouteChange = () => {
+    let route = {
+      location: this.props.location,
+      params: this.props.params
+    };
+
+    dispatcher.actions.ContextActions.changeRoute(route);
+  }
+
+  componentDidMount() {
+    this.triggerRouteChange();
+  }
+
+  componentDidUpdate() {
+    this.triggerRouteChange();
+  }
+
   render() {
     return (
       <div>

--- a/src/StorefrontSDK.js
+++ b/src/StorefrontSDK.js
@@ -33,11 +33,6 @@ class StorefrontSDK {
   }
 
   init() {
-    // Listen to route changes
-    this.history.listen((location) => {
-      this.dispatcher.actions.ContextActions.changeRoute(location);
-    });
-
     let components = this.dispatcher.stores.ComponentStore.getState();
 
     // Create routes based on the declared storefront components

--- a/src/actions/ContextActions.js
+++ b/src/actions/ContextActions.js
@@ -1,6 +1,6 @@
 class RouteActions {
-  changeRoute(location) {
-    return location;
+  changeRoute(route) {
+    return route;
   }
 }
 

--- a/src/stores/ContextStore.js
+++ b/src/stores/ContextStore.js
@@ -11,9 +11,8 @@ class ContextStore {
     this.state = Immutable.fromJS(window._storefront.context);
   }
 
-  onChangeRoute(location) {
-    let route = Immutable.fromJS(location);
-    this.setState(this.state.set('route', route));
+  onChangeRoute(route) {
+    this.setState(this.state.set('route', Immutable.fromJS(route)));
   }
 }
 


### PR DESCRIPTION
The route object now contains info about the params of the route.

```js
{
  route: {
    location: {
      action: "POP",
      hash: "",
      key: "vkioqa",
      pathname: "/camisa-polo/p",
      query: Object,
      search: "",
     state: null
    },
    params: {
      slug: "camisa-polo"
    }
  }
}
```