### PR TITLE
Area and API changes

### DIFF
--- a/docs/pt/api/stores/ProductStore.md
+++ b/docs/pt/api/stores/ProductStore.md
@@ -112,7 +112,7 @@
 
 ### Actions relacionadas
 
-- [`ResourceActions.getRouteResources`](../actions/ResourceActions.md): pega os resources da página
+- [`ResourceActions.getAreaResources`](../actions/ResourceActions.md): pega os resources da página
 - [`SearchActions.onRequestSearch`](../actions/SearchActions.md): faz uma busca por produtos
 - [`ProductActions.requestProduct`](../actions/ProductActions.md): pega dados de um produto específico
 

--- a/docs/pt/api/stores/ResourceStore.md
+++ b/docs/pt/api/stores/ResourceStore.md
@@ -26,7 +26,7 @@
 
 ### Actions relacionadas
 
-- [`ResourceActions.getRouteResources`](../actions/ResourceActions.md): pega os resources da página
+- [`ResourceActions.getAreaResources`](../actions/ResourceActions.md): pega os resources da página
 
 ### Exemplo
 
@@ -39,7 +39,7 @@ class HomePage extends React.Component {
     let currentURL = (window.location.pathname + window.location.search);
 
     if (!stores.ResourceStore.getState().get(currentURL)) {
-      actions.ResourceActions.getRouteResources(currentURL, 'home');
+      actions.ResourceActions.getAreaResources(currentURL, 'home');
     }
   }
 

--- a/docs/pt/api/stores/SettingsStore.md
+++ b/docs/pt/api/stores/SettingsStore.md
@@ -28,7 +28,7 @@
 
 ### Actions relacionadas
 
-- [`ResourceActions.getRouteResources`](../actions/ResourceActions.md): pega os resources da página
+- [`ResourceActions.getAreaResources`](../actions/ResourceActions.md): pega os resources da página
 
 ### Exemplo
 

--- a/src/StorefrontSDK.js
+++ b/src/StorefrontSDK.js
@@ -16,6 +16,7 @@ import dispatcher from './dispatcher/StorefrontDispatcher';
 import connectToStores from './utils/connectToStores';
 import Price from './utils/Price';
 import Img from './utils/Img';
+import Area from './components/Area';
 import App from './App';
 
 let history = useQueries(createHistory)();
@@ -26,6 +27,8 @@ class StorefrontSDK {
   stores = dispatcher.stores;
 
   history = history;
+
+  Area = Area;
 
   utils = {
     connectToStores,

--- a/src/StorefrontSDK.js
+++ b/src/StorefrontSDK.js
@@ -17,7 +17,7 @@ import connectToStores from './utils/connectToStores';
 import Price from './utils/Price';
 import Img from './utils/Img';
 import Area from './components/Area';
-import App from './App';
+import App from './components/App';
 
 let history = useQueries(createHistory)();
 

--- a/src/actions/ResourceActions.js
+++ b/src/actions/ResourceActions.js
@@ -20,23 +20,29 @@ class ResourceActions {
     return error;
   }
 
-  getAreaResources(currentURL, area, params = {}, query = {}) {
+  getAreaResources({currentURL, id, params = {}, query = {}}) {
 
-    storefrontService.getAreaResources(area, params, query)
-    .then((response) =>
-      this.actions.getAreaResourcesSuccess(currentURL, area, params, response.data.resources)
-    ).catch((error) =>
-      this.actions.getAreaResourcesError(currentURL, area, params, error)
+    storefrontService.getAreaResources({id, params, query})
+    .then((response) => {
+      let result = {
+        currentURL,
+        id,
+        params,
+        resources: response.data.resources
+      };
+      this.actions.getAreaResourcesSuccess(result);
+    }).catch((error) =>
+      this.actions.getAreaResourcesError({currentURL, id, params, error})
     );
 
     return {currentURL, area, params};
   }
 
-  getAreaResourcesSuccess(currentURL, area, params, resources) {
+  getAreaResourcesSuccess({currentURL, area, params, resources}) {
     return {currentURL, area, params, resources};
   }
 
-  getAreaResourcesError(currentURL, area, params, error) {
+  getAreaResourcesError({currentURL, area, params, error}) {
     return {currentURL, area, params, error};
   }
 }

--- a/src/actions/ResourceActions.js
+++ b/src/actions/ResourceActions.js
@@ -21,16 +21,13 @@ class ResourceActions {
   }
 
   getAreaResources(currentURL, area, params = {}, query = {}) {
-    let resources = storefrontService.getAreaResources(area, params, query);
-    let settings = storefrontService.getAreaSettings(area);
 
-    Promise.all([resources, settings])
-      .then((response) => {
-        let [resourcesResponse, settingsResponse ] = response;
-        resourcesResponse.data.resources._settings = settingsResponse.data;
-        this.actions.getAreaResourcesSuccess(currentURL, area, params, resourcesResponse.data.resources);
-      })
-      .catch((error) => this.actions.getAreaResourcesError(currentURL, area, params, error));
+    storefrontService.getAreaResources(area, params, query)
+    .then((response) =>
+      this.actions.getAreaResourcesSuccess(currentURL, area, params, response.data.resources)
+    ).catch((error) =>
+      this.actions.getAreaResourcesError(currentURL, area, params, error)
+    );
 
     return {currentURL, area, params};
   }

--- a/src/actions/ResourceActions.js
+++ b/src/actions/ResourceActions.js
@@ -4,10 +4,10 @@ let storefrontService = new Storefront();
 
 class ResourceActions {
 
-  saveSettings({accountName, route, component, id, settings}) {
-    storefrontService.saveAreaSettings({accountName, route, component, id, settings})
-      .then(() => this.actions.saveSettingsSuccess({route, id, settings}))
-      .catch(this.actions.saveSettingsError);
+  saveSettings({id, component, settings}) {
+    storefrontService.saveAreaSettings({id, component, settings})
+      .then(() => this.actions.saveSettingsSuccess({id, settings}))
+      .catch((error) => this.actions.saveSettingsError({id, settings, error}));
 
     return arguments[0];
   }

--- a/src/actions/ResourceActions.js
+++ b/src/actions/ResourceActions.js
@@ -5,7 +5,7 @@ let storefrontService = new Storefront();
 class ResourceActions {
 
   saveSettings({accountName, route, component, id, settings}) {
-    storefrontService.saveComponentSettings({accountName, route, component, id, settings})
+    storefrontService.saveAreaSettings({accountName, route, component, id, settings})
       .then(() => this.actions.saveSettingsSuccess({route, id, settings}))
       .catch(this.actions.saveSettingsError);
 
@@ -20,27 +20,27 @@ class ResourceActions {
     return error;
   }
 
-  getRouteResources(currentURL, route, params = {}, query = {}) {
-    let resources = storefrontService.getRouteResources(route, params, query);
-    let settings = storefrontService.getComponentSettings(route);
+  getAreaResources(currentURL, area, params = {}, query = {}) {
+    let resources = storefrontService.getAreaResources(area, params, query);
+    let settings = storefrontService.getAreaSettings(area);
 
     Promise.all([resources, settings])
       .then((response) => {
         let [resourcesResponse, settingsResponse ] = response;
         resourcesResponse.data.resources._settings = settingsResponse.data;
-        this.actions.getRouteResourcesSuccess(currentURL, route, params, resourcesResponse.data.resources);
+        this.actions.getAreaResourcesSuccess(currentURL, area, params, resourcesResponse.data.resources);
       })
-      .catch((error) => this.actions.getRouteResourcesError(currentURL, route, params, error));
+      .catch((error) => this.actions.getAreaResourcesError(currentURL, area, params, error));
 
-    return {currentURL, route, params};
+    return {currentURL, area, params};
   }
 
-  getRouteResourcesSuccess(currentURL, route, params, resources) {
-    return {currentURL, route, params, resources};
+  getAreaResourcesSuccess(currentURL, area, params, resources) {
+    return {currentURL, area, params, resources};
   }
 
-  getRouteResourcesError(currentURL, route, params, error) {
-    return {currentURL, route, params, error};
+  getAreaResourcesError(currentURL, area, params, error) {
+    return {currentURL, area, params, error};
   }
 }
 

--- a/src/actions/ResourceActions.js
+++ b/src/actions/ResourceActions.js
@@ -35,15 +35,15 @@ class ResourceActions {
       this.actions.getAreaResourcesError({currentURL, id, params, error})
     );
 
-    return {currentURL, area, params};
+    return {currentURL, id, params};
   }
 
-  getAreaResourcesSuccess({currentURL, area, params, resources}) {
-    return {currentURL, area, params, resources};
+  getAreaResourcesSuccess({currentURL, id, params, resources}) {
+    return {currentURL, id, params, resources};
   }
 
-  getAreaResourcesError({currentURL, area, params, error}) {
-    return {currentURL, area, params, error};
+  getAreaResourcesError({currentURL, id, params, error}) {
+    return {currentURL, id, params, error};
   }
 }
 

--- a/src/actions/ResourceActions.js
+++ b/src/actions/ResourceActions.js
@@ -12,8 +12,8 @@ class ResourceActions {
     return arguments[0];
   }
 
-  saveSettingsSuccess(settings) {
-    return settings;
+  saveSettingsSuccess(data) {
+    return data;
   }
 
   saveSettingsError(error) {

--- a/src/actions/ResourceActions.js
+++ b/src/actions/ResourceActions.js
@@ -22,7 +22,7 @@ class ResourceActions {
 
   getRouteResources(currentURL, route, params = {}, query = {}) {
     let resources = storefrontService.getRouteResources(route, params, query);
-    let settings = storefrontService.getRouteSettings(route);
+    let settings = storefrontService.getComponentSettings(route);
 
     Promise.all([resources, settings])
       .then((response) => {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import dispatcher from './dispatcher/StorefrontDispatcher';
+import dispatcher from '../dispatcher/StorefrontDispatcher';
 
 class App extends React.Component {
   triggerRouteChange = () => {

--- a/src/components/Area.js
+++ b/src/components/Area.js
@@ -43,9 +43,9 @@ class Area extends React.Component {
   getDataFromStores = (props) => {
     const componentSettings = dispatcher.stores.SettingsStore.getState().get(props.id);
     if (!componentSettings) {
-      console.warn(`Area: there\'s no such area with the id ${props.id}`);
       return { setings: null, component: null };
     }
+
     const settings = componentSettings.get('settings');
     const componentName = props.component ? props.component : componentSettings.get('component');
     const component = dispatcher.stores.ComponentStore.getState().getIn([componentName, 'constructor']);

--- a/src/components/Area.js
+++ b/src/components/Area.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import dispatcher from '../dispatcher/StorefrontDispatcher';
+import shallowCompare from 'react-addons-shallow-compare';
+import mergeDeep from 'utils/mergeDeep';
+
+/**
+ *  <Area id="home/banner"/>
+ *  It will render the component saved at "home/banner" passing its
+ *  settings as props.
+ *
+ *  You can also fix a component to be rendered:
+ *  <Area component="Banner@vtex.storefront-theme" id="home/banner"/>
+ *  It will *always* render the component `Banner@vtex.storefront-theme`,
+ *  you need to make sure to have its assets added in the page though.
+ *  Storefront won't make that for you.
+ *
+ *  You can also pass some fixed settings that will override the saved
+ *  settings:
+ *  <Area id="home/banner" settings={{title: 'Hi!'}}/>
+ *
+ *  Or, you can ignore the prop "id" and make everything fixed:
+ *  <Area component="Banner@vtex.storefront-theme" settings={{title: 'Hi'}}/>
+ */
+class Area extends React.Component {
+  constructor(props) {
+    super(props);
+
+    if (!props.id) {
+      console.error('Area: required prop "id" not defined');
+    }
+
+    this.state = this.getDataFromStores(props);
+
+    dispatcher.stores.SettingsStore.listen(this.onChange);
+    dispatcher.stores.ComponentStore.listen(this.onChange);
+  }
+
+  componentWillUnmount = () => {
+    dispatcher.stores.SettingsStore.unlisten(this.onChange);
+    dispatcher.stores.ComponentStore.unlisten(this.onChange);
+  }
+
+  getDataFromStores = (props) => {
+    const componentSettings = dispatcher.stores.SettingsStore.getState().get(props.id);
+    if (!componentSettings) {
+      console.warn(`Area: there\'s no such area with the id ${props.id}`);
+      return { setings: null, component: null };
+    }
+    const settings = componentSettings.get('settings');
+    const componentName = props.component ? props.component : componentSettings.get('component');
+    const component = dispatcher.stores.ComponentStore.getState().getIn([componentName, 'constructor']);
+
+    if (!component) {
+      if (typeof props.component !== 'undefined' && typeof props.component !== 'string') {
+        console.warn(`Area: "component" prop should be a component locator (eg: ComponentName@vendor.appName)`);
+      } else {
+        console.warn(`Area: Could not find component ${componentName}`);
+      }
+    }
+
+    return {
+      settings: settings ? settings : Immutable.Map(),
+      component: component
+    };
+  }
+
+  onChange = () => {
+    this.setState(this.getDataFromStores(this.props));
+  }
+
+  shouldComponentUpdate = (nextProps, nextState) => {
+    return shallowCompare(this, nextProps, nextState);
+  }
+
+  render() {
+    const settings = mergeDeep(this.state.settings, this.props.settings);
+    const Component = this.state.component;
+
+    if (!Component) {
+      return null;
+    }
+
+    return (
+      <Component {...this.props} settings={settings.isEmpty() ? null : settings}/>
+    );
+  }
+}
+
+export default Area;

--- a/src/services/Search.js
+++ b/src/services/Search.js
@@ -5,14 +5,15 @@ class Search {
   constructor() {
     let token = ('; ' + document.cookie).split('; VtexIdclientAutCookie=').pop().split(';').shift();
     let workspace = ('; ' + document.cookie).split('; vtex_workspace=').pop().split(';').shift();
+    let accountName = global._storefront.context.accountName;
 
     this.defaultHeaders = {
       'Authorization': `token ${token}`,
       'x-vtex-workspace': workspace ? workspace : 'master'
     };
 
-    this.productResource = '/_resources/product@vtex.storefront-sdk/';
-    this.productsResource = '/_resources/products@vtex.storefront-sdk/';
+    this.productResource = `/_proxy/product@vtex.storefront-sdk/${accountName}/product`;
+    this.productsResource = `/_proxy/products@vtex.storefront-sdk/${accountName}/products`;
   }
 
   products(params) {

--- a/src/services/Storefront.js
+++ b/src/services/Storefront.js
@@ -33,8 +33,8 @@ class Storefront {
     });
   }
 
-  getAreaSettings(component) {
-    return axios.get(`/_resources/_settings/?id=${component}`, {
+  getAreaSettings({id}) {
+    return axios.get(`/_resources/_settings/?route=${id}`, {
       headers: this.defaultHeaders
     });
   }

--- a/src/services/Storefront.js
+++ b/src/services/Storefront.js
@@ -11,9 +11,9 @@ class Storefront {
     };
   }
 
-  saveComponentSettings({route, id, component, settings}) {
+  saveComponentSettings({id, component, settings}) {
     const url = `/_resources/_settings/`;
-    const params = { route, id };
+    const params = { id };
     const data = { component, settings };
 
     return axios.put(url, data, {
@@ -33,8 +33,8 @@ class Storefront {
     });
   }
 
-  getRouteSettings(route) {
-    return axios.get(`/_resources/_settings/?route=${route}`, {
+  getComponentSettings(component) {
+    return axios.get(`/_resources/_settings/?id=${component}`, {
       headers: this.defaultHeaders
     });
   }

--- a/src/services/Storefront.js
+++ b/src/services/Storefront.js
@@ -11,7 +11,7 @@ class Storefront {
     };
   }
 
-  saveComponentSettings({id, component, settings}) {
+  saveAreaSettings({id, component, settings}) {
     const url = `/_resources/_settings/`;
     const params = { id };
     const data = { component, settings };
@@ -22,7 +22,7 @@ class Storefront {
     });
   }
 
-  getRouteResources(route, params, query) {
+  getAreaResources(route, params, query) {
     for (let key in query) {
       params[`query.${key}`] = query[key];
     }
@@ -33,7 +33,7 @@ class Storefront {
     });
   }
 
-  getComponentSettings(component) {
+  getAreaSettings(component) {
     return axios.get(`/_resources/_settings/?id=${component}`, {
       headers: this.defaultHeaders
     });

--- a/src/services/Storefront.js
+++ b/src/services/Storefront.js
@@ -22,12 +22,12 @@ class Storefront {
     });
   }
 
-  getAreaResources(route, params, query) {
+  getAreaResources({id, params, query}) {
     for (let key in query) {
       params[`query.${key}`] = query[key];
     }
 
-    return axios.get(`/_routes/${route}/resources/`, {
+    return axios.get(`/_routes/${id}/resources/`, {
       headers: this.defaultHeaders,
       params
     });

--- a/src/stores/CategoryStore.js
+++ b/src/stores/CategoryStore.js
@@ -34,7 +34,7 @@ class CategoryStore {
     this.state = getDataFromResources(Immutable.Map(), resources);
   }
 
-  onGetRouteResourcesSuccess({ resources }) {
+  onGetAreaResourcesSuccess({ resources }) {
     this.setState(getDataFromResources(this.state, resources));
   }
 }

--- a/src/stores/ComponentStore.js
+++ b/src/stores/ComponentStore.js
@@ -5,12 +5,6 @@ import immutable from 'alt/utils/ImmutableUtil';
 let _getComponentProperties = function _getComponentProperties(state, _component) {
   let { name, role, area, constructor } = _component;
 
-  if (_component.constructor && _component.constructor.storefront) {
-    name = _component.constructor.storefront.name;
-    role = _component.constructor.storefront.role;
-    area = _component.constructor.storefront.area;
-  }
-
   let component = Immutable.Map({
     role,
     area,

--- a/src/stores/FacetsStore.js
+++ b/src/stores/FacetsStore.js
@@ -26,7 +26,7 @@ class FacetsStore {
     this.state = getDataFromResources(Immutable.Map(), resources);
   }
 
-  onGetRouteResourcesSuccess({ resources }) {
+  onGetAreaResourcesSuccess({ resources }) {
     this.setState(getDataFromResources(this.state, resources));
   }
 }

--- a/src/stores/ProductStore.js
+++ b/src/stores/ProductStore.js
@@ -72,7 +72,7 @@ class ProductStore {
     this.setState(addProducts(this.state, products));
   }
 
-  onGetRouteResourcesSuccess({ resources }) {
+  onGetAreaResourcesSuccess({ resources }) {
     this.setState(getDataFromResources(this.state, resources));
   }
 }

--- a/src/stores/ResourceStore.js
+++ b/src/stores/ResourceStore.js
@@ -18,15 +18,15 @@ class ResourceStore {
     this.state = getDataFromResources(Immutable.Map(), currentURL, window.storefront.currentRoute.resources);
   }
 
-  onGetRouteResources({currentURL}) {
+  onGetAreaResources({currentURL}) {
     this.setState(this.state.set(currentURL, Immutable.Map()));
   }
 
-  onGetRouteResourcesSuccess({currentURL, resources}) {
+  onGetAreaResourcesSuccess({currentURL, resources}) {
     this.setState(getDataFromResources(this.state, currentURL, resources));
   }
 
-  onGetRouteResourcesError({currentURL, error}) {
+  onGetAreaResourcesError({currentURL, error}) {
     let newState = this.state.withMutations(map =>
       map.setIn([currentURL, 'resources'], null)
          .setIn([currentURL, 'error', error])

--- a/src/stores/SearchStore.js
+++ b/src/stores/SearchStore.js
@@ -62,7 +62,7 @@ class SearchStore {
     this.setState(this.state.setIn([params, 'error'], error));
   }
 
-  onGetRouteResourcesSuccess({resources}) {
+  onGetAreaResourcesSuccess({resources}) {
     this.setState(getDataFromResources(this.state, resources));
   }
 }

--- a/src/stores/SettingsStore.js
+++ b/src/stores/SettingsStore.js
@@ -30,7 +30,7 @@ class SettingsStore {
     this.setState(this.oldState);
   }
 
-  onGetRouteResourcesSuccess({resources}) {
+  onGetAreaResourcesSuccess({resources}) {
     this.setState(getDataFromResources(this.state, resources));
   }
 }

--- a/src/stores/SettingsStore.js
+++ b/src/stores/SettingsStore.js
@@ -1,10 +1,10 @@
 import Immutable from 'immutable';
 import immutable from 'alt/utils/ImmutableUtil';
 
-function getDataFromResources(state, route, resources) {
+function getDataFromResources(state, resources) {
   if (resources._settings) {
     let settings = resources._settings;
-    return state.set(route, Immutable.fromJS(settings));
+    return state.merge(Immutable.fromJS(settings));
   }
   return state;
 }
@@ -14,14 +14,14 @@ class SettingsStore {
   constructor(dispatcher) {
     this.bindActions(dispatcher.actions.ResourceActions);
 
-    this.state = getDataFromResources(Immutable.Map(), window.storefront.currentRoute.name, window.storefront.currentRoute.resources);
+    this.state = getDataFromResources(Immutable.Map(), window.storefront.currentRoute.resources);
   }
 
-  onSaveSettings({route, id, settings}) {
+  onSaveSettings({id, settings}) {
     // Here we are doing an optmistic update. The data is not saved on the
     // server yet, but it probably will.
     this.oldState = this.state;
-    this.setState(this.state.setIn([route, id, 'settings'], Immutable.Map(settings)));
+    this.setState(this.state.setIn([id, 'settings'], Immutable.Map(settings)));
   }
 
   onSaveSettingsFail(error) {
@@ -30,8 +30,8 @@ class SettingsStore {
     this.setState(this.oldState);
   }
 
-  onGetRouteResourcesSuccess({route, resources}) {
-    this.setState(getDataFromResources(this.state, route, resources));
+  onGetRouteResourcesSuccess({resources}) {
+    this.setState(getDataFromResources(this.state, resources));
   }
 }
 

--- a/src/utils/connectToStores.js
+++ b/src/utils/connectToStores.js
@@ -63,9 +63,8 @@ function connectToStores() {
       }
 
       render() {
-        return React.createElement(
-          Component,
-          assign({}, this.props, this.state)
+        return (
+          <Component {...assign({}, this.props, this.state)}/>
         );
       }
     }

--- a/src/utils/mergeDeep.js
+++ b/src/utils/mergeDeep.js
@@ -1,0 +1,33 @@
+import Immutable from 'immutable';
+
+/**
+- *  This functions merges the saved settings with the hard coded settings
+- *  both parameters can be an Immutable Map or a JSON, the later will be
+- *  converted to an Immutable Map.
+- *  Always returns an Immutable Map
+- *
+- *  eg:
+- *    settings = Immutable.Map() with { title: 'Hi!', desc: 'World' }
+- *    codedSettings = { title: 'Always show this' }
+- *  returns:
+- *    Immutable.Map() with { title: 'Always show this', desc: 'World!' }
+- */
+export default function mergeDeep(settings, codedSettings) {
+  if (settings) {
+    if (!Immutable.Map.isMap(settings)) {
+      settings = Immutable.fromJS(settings);
+    }
+  } else {
+    settings = Immutable.Map();
+  }
+
+  if (codedSettings) {
+    if (!Immutable.Map.isMap(codedSettings)) {
+      codedSettings = Immutable.fromJS(codedSettings);
+    }
+  } else {
+    codedSettings = Immutable.Map();
+  }
+
+  return settings.mergeDeep(codedSettings);
+}

--- a/storefront/resources/categories.json
+++ b/storefront/resources/categories.json
@@ -1,4 +1,4 @@
 {
-  "url": "http://api.beta.vtex.com/:account/categories/",
+  "url": "http://api.beta.vtex.com",
   "cacheDuration": 60
 }

--- a/storefront/resources/categories.json
+++ b/storefront/resources/categories.json
@@ -1,7 +1,4 @@
 {
   "url": "http://api.beta.vtex.com/:account/categories/",
-  "cacheDuration": 60,
-  "parameters": {
-    "account": "{{ account.name }}"
-  }
+  "cacheDuration": 60
 }

--- a/storefront/resources/facets.json
+++ b/storefront/resources/facets.json
@@ -1,11 +1,4 @@
 {
   "url": "http://api.beta.vtex.com/:account/facets/",
-  "cacheDuration": 60,
-  "parameters": {
-    "account": "{{ account.name }}"
-  },
-  "queryString": {
-    "category": "{{ parameters.category }}",
-    "brands": "{{ parameters.brands }}"
-  }
+  "cacheDuration": 60
 }

--- a/storefront/resources/facets.json
+++ b/storefront/resources/facets.json
@@ -1,4 +1,4 @@
 {
-  "url": "http://api.beta.vtex.com/:account/facets/",
+  "url": "http://api.beta.vtex.com",
   "cacheDuration": 60
 }

--- a/storefront/resources/product.json
+++ b/storefront/resources/product.json
@@ -1,7 +1,4 @@
 {
   "url": "http://api.beta.vtex.com/:account/products/:slug",
-  "cacheDuration": 60,
-  "parameters": {
-    "account": "{{ account.name }}"
-  }
+  "cacheDuration": 60
 }

--- a/storefront/resources/product.json
+++ b/storefront/resources/product.json
@@ -1,4 +1,4 @@
 {
-  "url": "http://api.beta.vtex.com/:account/products/:slug",
+  "url": "http://api.beta.vtex.com",
   "cacheDuration": 60
 }

--- a/storefront/resources/products.json
+++ b/storefront/resources/products.json
@@ -1,15 +1,4 @@
 {
-  "url": "http://api.beta.vtex.com/:account/products/",
-  "cacheDuration": 60,
-  "parameters": {
-    "account": "{{ account.name }}"
-  },
-  "queryString": {
-    "query": "{{ parameters.query }}",
-    "category": "{{ parameters.category }}",
-    "brands": "{{ parameters.brands }}",
-    "sort": "{{ parameters.sort }}",
-    "page": "{{ parameters.page }}",
-    "pageSize": "{{ parameters.pageSize }}"
-  }
+  "url": "http://api.beta.vtex.com",
+  "cacheDuration": 60
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -82,6 +82,7 @@ module.exports = {
   resolve: {
     extensions: ['', '.js', '.jsx'],
     alias: {
+      'components': path.join(__dirname, '/src/components/'),
       'constants': path.join(__dirname, '/src/constants/'),
       'services': path.join(__dirname, '/src/services/'),
       'utils': path.join(__dirname, '/src/utils/')


### PR DESCRIPTION
This pull request contains:
- Area component
- Fix Storefront's API changes
- Small pieces of love (be careful children)

## Area
```js
<Area id="home/banner"/>
```
It will render the component saved at home/banner passing its settings as props.

You can also fix a component to be rendered:
```js
<Area component="Banner@vtex.storefront-theme" id="home/banner"/>
```
It will *always* render the component `Banner@vtex.storefront-theme`, you need to make sure to have its assets added in the page though. Storefront won't make that for you.

You can also pass some fixed settings that will extend the saved settings:
```js
<Area id="home/banner" settings={{title: 'Hi!'}}/>
```

Or, you can ignore the prop "id" and make everything fixed:
```js
<Area component="Banner@vtex.storefront-theme" settings={{title: 'Hi'}}/>
```

<!---
@huboard:{"order":1.4266774428506324e-09,"milestone_order":16,"custom_state":""}
-->
