### PR TITLE
Improve build

### DIFF
--- a/src/StorefrontSDK.js
+++ b/src/StorefrontSDK.js
@@ -4,12 +4,11 @@ import 'expose?Intl!intl';
 import 'expose?Immutable!immutable';
 import 'expose?ReactIntl!react-intl';
 import 'expose?axios!axios';
+import 'expose?alt!alt';
 
 import { map } from 'lodash-compat/collection';
 import createHistory from 'history/lib/createBrowserHistory';
 import useQueries from 'history/lib/useQueries';
-
-import immutableStore from 'alt/utils/ImmutableUtil';
 
 import dispatcher from './dispatcher/StorefrontDispatcher';
 import connectToStores from './utils/connectToStores';
@@ -28,7 +27,6 @@ class StorefrontSDK {
 
   storefront = storefront;
   connectToStores = connectToStores;
-  immutableStore = immutableStore;
   history = history;
 
   init() {

--- a/storefront/layout.html
+++ b/storefront/layout.html
@@ -30,7 +30,8 @@
 
   <div id="storefront-container"></div>
 
-  {% script 'storefront-libs.js@vtex.storefront-sdk' %}
+  {% script 'storefront-helper-libs.js@vtex.storefront-sdk' %}
+  {% script 'storefront-core-libs.js@vtex.storefront-sdk' %}
   {% script 'storefront-sdk.js@vtex.storefront-sdk' %}
 
   {% capture intlLocaleUrl %}//io.vtex.com.br/front-libs/intl/0.1.4/locale-data/jsonp/{{ culture.language | split: "-" | first }}.js{% endcapture %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,24 +5,25 @@ var meta = require('./meta.json');
 var publicPath = '/assets/@' + meta.vendor + '.' + pkg.name + '/';
 var production = process.env.NODE_ENV === 'production';
 
-var vendor = [
-  'react',
-  'react-router',
-  'intl',
-  'immutable',
-  'react-intl',
-  'axios'
-];
-
 var commonsConfig = {
-  name: 'vendor',
-  filename: 'storefront-libs.js',
+  name: ['core-libs', 'helper-libs'],
+  filename: 'storefront-[name].js',
   minChunks: Infinity
 };
 
 var entryPoints = {
-  '.': [ './src/index.js' ],
-  'vendor': vendor
+  '.': './src/index.js',
+  'helper-libs': [
+    'axios',
+    'immutable',
+    'intl'
+  ],
+  'core-libs': [
+    'alt',
+    'react',
+    'react-intl',
+    'react-router'
+  ]
 }
 
 module.exports = {


### PR DESCRIPTION
Create two separate entry points for the libraries, making it possible for the browser to load both at the same time, improving page speed.

Expose alt and, at the same time, remove SDK responsability to expose an **util** module of Alt. If the app wants to require this module, just add alt to the package dependencies and require just the util module, no extra overhead it's added to page.