### PR TITLE
Remove dependencies from app and add react-helmet 

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "alt": "^0.17.4",
     "lodash-compat": "^3.10.1",
     "react-addons-shallow-compare": "^0.14.2",
+    "react-helmet": "^2.1.1",
     "react-tap-event-plugin": "^0.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,16 +16,8 @@
   },
   "dependencies": {
     "alt": "^0.17.4",
-    "axios": "^0.7.0",
-    "history": "^1.12.5",
-    "immutable": "^3.7.5",
-    "intl": "^1.0.0",
     "lodash-compat": "^3.10.1",
-    "react": "^0.14.2",
     "react-addons-shallow-compare": "^0.14.2",
-    "react-dom": "^0.14.2",
-    "react-intl": "^2.0.0-pr-2",
-    "react-router": "^1.0.0-rc4",
     "react-tap-event-plugin": "^0.2.1"
   },
   "devDependencies": {

--- a/src/StorefrontSDK.js
+++ b/src/StorefrontSDK.js
@@ -1,15 +1,8 @@
-import 'expose?React!react';
-import 'expose?ReactDOM!react-dom';
-import 'expose?ReactRouter!react-router';
-import 'expose?Intl!intl';
-import 'expose?Immutable!immutable';
-import 'expose?ReactIntl!react-intl';
-import 'expose?axios!axios';
-import 'expose?alt!alt';
 
 import { map } from 'lodash-compat/collection';
-import createHistory from 'history/lib/createBrowserHistory';
-import useQueries from 'history/lib/useQueries';
+import { createHistory, useQueries } from 'history';
+import { Router, Route } from 'react-router';
+import ReactDOM from 'react-dom';
 
 import dispatcher from './dispatcher/StorefrontDispatcher';
 import storefront from './utils/storefront';
@@ -17,9 +10,6 @@ import connectToStores from './utils/connectToStores';
 import Price from './utils/Price';
 import Img from './utils/Img';
 import App from './App';
-
-let ReactDOM = window.ReactDOM;
-let { Router, Route } = window.ReactRouter;
 
 let history = useQueries(createHistory)();
 

--- a/src/StorefrontSDK.js
+++ b/src/StorefrontSDK.js
@@ -1,3 +1,4 @@
+import 'expose?ReactHelmet!react-helmet';
 
 import { map } from 'lodash-compat/collection';
 import { createHistory, useQueries } from 'history';

--- a/storefront/layout.html
+++ b/storefront/layout.html
@@ -30,13 +30,23 @@
 
   <div id="storefront-container"></div>
 
-  {% script 'storefront-libs.js@vtex.storefront-sdk' %}
-  {% script 'storefront-react-libs.js@vtex.storefront-sdk' %}
+  {% script '//npmcdn.com/react@0.14.2/dist/react.min.js' %}
+  {% script '//npmcdn.com/react-dom@0.14.2/dist/react-dom.min.js' %}
+
+  {% script '//npmcdn.com/alt@0.17.4/dist/alt.min.js' %}
+  {% script '//npmcdn.com/immutable@3.7.5/dist/immutable.min.js' %}
+  {% script '//npmcdn.com/intl@1.0.0/dist/Intl.min.js' %}
+  {% script '//npmcdn.com/react-intl@2.0.0-pr-2/dist/react-intl.min.js' %}
+  {% script '//npmcdn.com/axios@0.7.0/dist/axios.min.js' %}
+  {% script '//npmcdn.com/history@1.12.5/umd/History.min.js' %}
+  {% script '//npmcdn.com/react-router@1.0.0/umd/ReactRouter.min.js' %}
+
+  {% script 'storefront-sdk-libs.js@vtex.storefront-sdk' %}
   {% script 'storefront-sdk.js@vtex.storefront-sdk' %}
 
-  {% capture intlLocaleUrl %}//io.vtex.com.br/front-libs/intl/1.0.0/locale-data/jsonp/{{ culture.language }}.js{% endcapture %}
+  {% capture intlLocaleUrl %}//npmcdn.com/intl@1.0.0/locale-data/jsonp/{{ culture.language }}.js{% endcapture %}
   {% script intlLocaleUrl %}
-  {% capture reactLocaleUrl %}//io.vtex.com.br/front-libs/react-intl/2.0.0-pr-2/locale-data/{{ culture.language }}.js{% endcapture %}
+  {% capture reactLocaleUrl %}//npmcdn.com/react-intl@2.0.0-pr-2/dist/locale-data/{{ culture.language }}.js{% endcapture %}
   {% script reactLocaleUrl %}
   <script>
     window.addEventListener('load', function () {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,32 +6,23 @@ var publicPath = '/assets/@' + meta.vendor + '.' + pkg.name + '/';
 var production = process.env.NODE_ENV === 'production';
 
 var commonsConfig = {
-  name: ['react-libs', 'libs'],
+  name: ['sdk-libs'],
   filename: 'storefront-[name].js',
-  minChunks: Infinity
+  minChunks: Infinity,
 };
 
 module.exports = {
   entry: {
     '.': './src/index.js',
-    'libs': [
-      'alt',
-      'axios',
-      'immutable',
-      'intl'
-    ],
-    'react-libs': [
-      'react',
-      'react-dom',
-      'react-intl',
-      'react-router'
+    'sdk-libs': [
+      'react-helmet'
     ]
   },
 
   module: {
     preLoaders: [
       {
-        test: /\.js$|\.jsx$/,
+        test: /\.js$/,
         include: path.join(__dirname, 'src'),
         exclude: /node_modules/,
         loader: 'eslint-loader'
@@ -40,7 +31,7 @@ module.exports = {
 
     loaders: [
       {
-        test: /\.js$|\.jsx$/,
+        test: /\.js$/,
         include: path.join(__dirname, 'src'),
         exclude: /node_modules/,
         loader: 'babel'
@@ -55,19 +46,30 @@ module.exports = {
     new webpack.optimize.CommonsChunkPlugin(commonsConfig),
     new webpack.SourceMapDevToolPlugin({
       filename: '[file].map',
-      exclude: ['storefront-react-libs.js', 'storefront-libs.js']
+      exclude: ['storefront-sdk-libs.js']
     }),
     new webpack.optimize.UglifyJsPlugin({compressor: {warnings: false}})
   ] : [
     new webpack.optimize.OccurenceOrderPlugin(),
-    new webpack.PrefetchPlugin('lodash-compat'),
     new webpack.NoErrorsPlugin(),
     new webpack.optimize.CommonsChunkPlugin(commonsConfig),
     new webpack.SourceMapDevToolPlugin({
       filename: '[file].map',
-      exclude: ['storefront-react-libs.js', 'storefront-libs.js']
+      exclude: ['storefront-sdk-libs.js']
     })
   ],
+
+  externals: {
+    'alt': 'Alt',
+    'axios': 'axios',
+    'immutable': 'Immutable',
+    'intl': 'Intl',
+    'react': 'React',
+    'history': 'History',
+    'react-dom': 'ReactDOM',
+    'react-intl': 'ReactIntl',
+    'react-router': 'ReactRouter'
+  },
 
   resolve: {
     extensions: ['', '.js', '.jsx'],


### PR DESCRIPTION
In this pull request I removed the dependencies from the bundle of the app and added them through the `layout.html` using script tags and npmcdn. I had to do this because the app was too big, it had files >1MB, so the only way I managed to make it smaller was to remove this files from the app and use remote assets.

Also I added react-helmet (my original intent from all of this hehe).