### PR TITLE
Add router onEnter and onLeave hooks

### DIFF
--- a/src/StorefrontSDK.js
+++ b/src/StorefrontSDK.js
@@ -34,7 +34,21 @@ class StorefrontSDK {
     // Create routes based on the declared storefront components
     let children = map(window.storefront.routes, (route, routeName) => {
       let component = components.getIn([route.component, 'constructor']);
-      return <Route path={route.path} component={component} key={routeName}/>;
+
+      let routeProps = {
+        path: route.path,
+        component: component,
+        key: routeName
+      };
+
+      if (component.onEnter) {
+        routeProps.onEnter = component.onEnter;
+      }
+      if (component.onLeave) {
+        routeProps.onLeave = component.onLeave;
+      }
+
+      return <Route {...routeProps}/>;
     });
 
     let wrapper = (


### PR DESCRIPTION
The route component should add a static method called `onEnter` and/or `onLeave`.

React Router docs about those functions: https://github.com/rackt/react-router/blob/master/docs/API.md#onenternextstate-replacestate-callback