### PR TITLE
Fix touch events

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,14 @@
   },
   "dependencies": {
     "alt": "^0.17.4",
+    "history": "^1.13.0",
     "lodash-compat": "^3.10.1",
+    "react": "^0.14.2",
     "react-addons-shallow-compare": "^0.14.2",
+    "react-dom": "^0.14.2",
     "react-helmet": "^2.1.1",
+    "react-intl": "^2.0.0-beta-1",
+    "react-router": "^1.0.0",
     "react-tap-event-plugin": "^0.2.1"
   },
   "devDependencies": {

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import dispatcher from './dispatcher/StorefrontDispatcher';
-import { IntlProvider } from 'react-intl';
 
 class App extends React.Component {
   triggerRouteChange = () => {
@@ -22,9 +21,9 @@ class App extends React.Component {
 
   render() {
     return (
-      <IntlProvider>
+      <div>
         {this.props.children}
-      </IntlProvider>
+      </div>
     );
   }
 }

--- a/src/StorefrontSDK.js
+++ b/src/StorefrontSDK.js
@@ -1,8 +1,13 @@
+import 'expose?React!react';
+import 'expose?ReactDom!react-dom';
+import 'expose?ReactRouter!react-router';
+import 'expose?ReactIntl!react-intl';
 import 'expose?ReactHelmet!react-helmet';
 
 import { map } from 'lodash-compat/collection';
 import { createHistory, useQueries } from 'history';
 import { Router, Route } from 'react-router';
+import { IntlProvider } from 'react-intl';
 import ReactDOM from 'react-dom';
 
 import dispatcher from './dispatcher/StorefrontDispatcher';
@@ -67,10 +72,14 @@ class StorefrontSDK {
     }
 
     // Finally, render
+    let locale = this.dispatcher.stores.ContextStore.getState().getIn(['culture', 'language']);
+    ReactIntl.addLocaleData(ReactIntlLocaleData[locale]);
     ReactDOM.render(
-      <Router history={this.history}>
-        {wrapper}
-      </Router>
+      <IntlProvider locale={locale}>
+        <Router history={this.history}>
+          {wrapper}
+        </Router>
+      </IntlProvider>
     , document.getElementById('storefront-container'));
   }
 }

--- a/storefront/layout.html
+++ b/storefront/layout.html
@@ -30,29 +30,20 @@
 
   <div id="storefront-container"></div>
 
-  {% script '//npmcdn.com/react@0.14.2/dist/react.min.js' %}
-  {% script '//npmcdn.com/react-dom@0.14.2/dist/react-dom.min.js' %}
+  {% script 'storefront-sdk-libs.js@vtex.storefront-sdk' %}
 
   {% script '//npmcdn.com/alt@0.17.4/dist/alt.min.js' %}
   {% script '//npmcdn.com/immutable@3.7.5/dist/immutable.min.js' %}
   {% script '//npmcdn.com/intl@1.0.0/dist/Intl.min.js' %}
-  {% script '//npmcdn.com/react-intl@2.0.0-pr-2/dist/react-intl.min.js' %}
   {% script '//npmcdn.com/axios@0.7.0/dist/axios.min.js' %}
   {% script '//npmcdn.com/history@1.12.5/umd/History.min.js' %}
-  {% script '//npmcdn.com/react-router@1.0.0/umd/ReactRouter.min.js' %}
-
-  {% script 'storefront-sdk-libs.js@vtex.storefront-sdk' %}
-  {% script 'storefront-sdk.js@vtex.storefront-sdk' %}
 
   {% capture intlLocaleUrl %}//npmcdn.com/intl@1.0.0/locale-data/jsonp/{{ culture.language }}.js{% endcapture %}
   {% script intlLocaleUrl %}
-  {% capture reactLocaleUrl %}//npmcdn.com/react-intl@2.0.0-pr-2/dist/locale-data/{{ culture.language }}.js{% endcapture %}
+  {% capture reactLocaleUrl %}//npmcdn.com/react-intl@2.0.0-beta-1/dist/locale-data/{{ culture.language }}.js{% endcapture %}
   {% script reactLocaleUrl %}
-  <script>
-    window.addEventListener('load', function () {
-      ReactIntl.addLocaleData(ReactIntlLocaleData.{{ culture.language }});
-    });
-  </script>
+
+  {% script 'storefront-sdk.js@vtex.storefront-sdk' %}
 
   <script>
     window._storefront = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,11 @@ module.exports = {
   entry: {
     '.': './src/index.js',
     'sdk-libs': [
+      'react',
+      'react-dom',
+      'react-tap-event-plugin',
+      'react-router',
+      'react-intl',
       'react-helmet'
     ]
   },
@@ -64,11 +69,7 @@ module.exports = {
     'axios': 'axios',
     'immutable': 'Immutable',
     'intl': 'Intl',
-    'react': 'React',
-    'history': 'History',
-    'react-dom': 'ReactDOM',
-    'react-intl': 'ReactIntl',
-    'react-router': 'ReactRouter'
+    'history': 'History'
   },
 
   resolve: {


### PR DESCRIPTION
react-tap-event-plugin must built with React. So I had to remove some
dependencies from npmcdn and build it in SDK.

Along with this, react-intl was updated to v2.0.0-beta-1.