### PR TITLE
Improve connectToStores

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "alt": "^0.17.4",
     "debounce": "^1.0.0",
+    "hoist-non-react-statics": "^1.0.3",
     "lodash-compat": "^3.10.1",
     "react": "^0.14.3",
     "react-addons-css-transition-group": "^0.14.3",

--- a/src/utils/connectToStores.js
+++ b/src/utils/connectToStores.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import shallowCompare from 'react-addons-shallow-compare';
 import isFunction from 'lodash-compat/lang/isFunction';
-import keys from 'lodash-compat/object/keys';
+import hoistStatics from 'hoist-non-react-statics';
 
 /**
  *    import { stores, utils } from 'sdk';
@@ -71,16 +71,9 @@ function connectToStores() {
       }
     }
 
-    StoreConnection.contextTypes = Component.contextTypes;
-    let staticProperties = keys(Component);
-
-    for (let i = 0; i < staticProperties.length; i++) {
-      let property = staticProperties[i];
-      StoreConnection[property] = Component[property];
-    }
     StoreConnection.displayName = `Connected${getDisplayName(Component)}`;
 
-    return StoreConnection;
+    return hoistStatics(StoreConnection, Component);
   };
 }
 

--- a/src/utils/connectToStores.js
+++ b/src/utils/connectToStores.js
@@ -2,7 +2,6 @@ import React from 'react';
 import shallowCompare from 'react-addons-shallow-compare';
 import isFunction from 'lodash-compat/lang/isFunction';
 import keys from 'lodash-compat/object/keys';
-import assign from 'lodash-compat/object/assign';
 
 /**
  *    import { stores, utils } from 'sdk';
@@ -67,7 +66,7 @@ function connectToStores() {
 
       render() {
         return (
-          <Component {...assign({}, this.props, this.state)}/>
+          <Component {...{...this.props, ...this.state}}/>
         );
       }
     }

--- a/src/utils/connectToStores.js
+++ b/src/utils/connectToStores.js
@@ -26,6 +26,11 @@ import assign from 'lodash-compat/object/assign';
  *
  *    export default MyComponent;
  */
+
+function getDisplayName(Component) {
+  return Component.displayName || Component.name || 'Component';
+}
+
 function connectToStores() {
   return function decorator(Component) {
     // Check for required static methods.
@@ -37,8 +42,6 @@ function connectToStores() {
     }
 
     class StoreConnection extends React.Component {
-      displayName = `Stateful${Component.displayName || Component.name || 'Container'}`
-
       constructor(props) {
         super(props);
 
@@ -76,6 +79,7 @@ function connectToStores() {
       let property = staticProperties[i];
       StoreConnection[property] = Component[property];
     }
+    StoreConnection.displayName = `Connected${getDisplayName(Component)}`;
 
     return StoreConnection;
   };


### PR DESCRIPTION
Reduce filesize, this was due to the removal of assign function.

Build| From | To
---|---|---
Dev build| 214kb| 209kb 
Prod Build| 60.9kb| 60.5kb

Fix wrapped component name.

Use [hoist-non-react-statics](https://github.com/mridgway/hoist-non-react-statics) (also used in react-redux connect) to copy static properties.