### PR TITLE
Add more flexibility on SDK

### DIFF
--- a/src/StorefrontSDK.js
+++ b/src/StorefrontSDK.js
@@ -12,11 +12,12 @@ import ReactDOM from 'react-dom';
 import dispatcher from './dispatcher/StorefrontDispatcher';
 import connectToStores from './utils/connectToStores';
 import Root from './components/Root';
-import loadPage from './utils/loadPage';
+import { loadScript, loadPage } from './utils/loadPage';
 
 import * as storefrontService from 'services/Storefront';
 
 import './utils/editable';
+import contextify from './utils/contextify';
 
 const history = useQueries(createHistory)();
 
@@ -32,6 +33,9 @@ class StorefrontSDK {
   }
 
   connectToStores = connectToStores
+  loadScript = loadScript
+  loadPage = loadPage
+  contextify = contextify
 
   init = () => {
     // Set history listener for navigation

--- a/src/actions/AreaActions.js
+++ b/src/actions/AreaActions.js
@@ -29,7 +29,7 @@ class AreaActions {
     return data;
   }
 
-  saveAreaSettingsError(error) {
+  saveAreaSettingsFail(error) {
     return error;
   }
 

--- a/src/components/Placeholder.js
+++ b/src/components/Placeholder.js
@@ -22,41 +22,24 @@ import mergeDeep from 'utils/mergeDeep';
  *  <Placeholder component="Banner@vtex.storefront-theme" settings={{title: 'Hi'}}/>
  */
 
-
 class Placeholder extends React.Component {
-  static contextTypes = {
-    parentId: React.PropTypes.string
-  }
-
-  static childContextTypes = {
-    parentId: React.PropTypes.string
-  }
-
-  getChildContext() {
-    return { parentId: this.state.fullId };
-  }
-
   componentWillMount() {
     if (!this.props.id) {
       console.error('Placeholder: required prop "id" not defined');
     }
 
-    this.state = this.getDataFromStores(this.props, this.context);
+    this.state = this.getDataFromStores(this.props);
 
     dispatcher.stores.SettingsStore.listen(this.onChange);
     dispatcher.stores.ComponentStore.listen(this.onChange);
   }
 
-  componentWillReceiveProps(props, context) {
-    this.setState(this.getDataFromStores(props, context));
+  componentWillReceiveProps(props) {
+    this.setState(this.getDataFromStores(props));
   }
 
-  shouldComponentUpdate(nextProps, nextState, nextContext) {
-    const currentParentId = this.context && this.context.parentId;
-    const nextParentId = nextContext && nextState.parentId;
-    const isParentIdEqual = currentParentId === nextParentId;
-
-    return !isParentIdEqual || shallowCompare(this, nextProps, nextState);
+  shouldComponentUpdate(nextProps, nextState) {
+    return shallowCompare(this, nextProps, nextState);
   }
 
   componentWillUnmount() {
@@ -64,19 +47,8 @@ class Placeholder extends React.Component {
     dispatcher.stores.ComponentStore.unlisten(this.onChange);
   }
 
-  getPlaceholderId = (props, context) => {
-    let id = props.id;
-
-    if (context.parentId) {
-      id = context.parentId + '/' + id;
-    }
-
-    return id;
-  }
-
-  getDataFromStores = (props, context) => {
-    const id = this.getPlaceholderId(props, context);
-    const componentSettings = dispatcher.stores.SettingsStore.getState().get(id);
+  getDataFromStores = (props) => {
+    const componentSettings = dispatcher.stores.SettingsStore.getState().get(props.id);
 
     if (!componentSettings) {
       return { setings: null, component: null };
@@ -96,13 +68,12 @@ class Placeholder extends React.Component {
 
     return {
       settings: settings ? settings : Immutable.Map(),
-      component: component,
-      fullId: id
+      component: component
     };
   }
 
   onChange = () => {
-    this.setState(this.getDataFromStores(this.props, this.context));
+    this.setState(this.getDataFromStores(this.props));
   }
 
   render() {
@@ -116,7 +87,6 @@ class Placeholder extends React.Component {
     return (
       <Component
         {...this.props}
-        id={this.state.fullId}
         settings={settings.isEmpty() ? null : settings}
       />
     );

--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import dispatcher from '../dispatcher/StorefrontDispatcher';
-import Placeholder from './Placeholder';
+import PurePlaceholder from './Placeholder';
+import contextify from 'utils/contextify';
+
+const Placeholder = contextify()(PurePlaceholder);
 
 class Root extends React.Component {
   static childContextTypes = {

--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -16,6 +16,7 @@ class Root extends React.Component {
   componentWillMount() {
     this.setState({
       location: this.getContextLocation(),
+      lockRoute: false,
       ...this.updatePage()
     });
   }
@@ -51,7 +52,7 @@ class Root extends React.Component {
 
     if (isPageLoading === false) {
       return {
-        route,
+        route: this.state.lockRoute ? (this.state.route || route) : route,
         params: ContextStore.get('params'),
         loaded: true
       };
@@ -60,14 +61,14 @@ class Root extends React.Component {
     return { loaded: false };
   }
 
+  setLockRoute = () => this.setState({ lockRoute: true })
+
   render() {
     const { loaded, params } = this.state;
     const location = this.state.location ? this.state.location.toJS() : {};
     const id = `${this.state.route}/content`;
 
-    if (!loaded) {
-      return null;
-    }
+    if (!loaded) return null;
 
     return (
       <div className="theme">
@@ -75,6 +76,7 @@ class Root extends React.Component {
           id={id}
           params={params}
           location={location}
+          setLockRoute={this.setLockRoute}
         />
       </div>
     );

--- a/src/dispatcher/StorefrontDispatcher.js
+++ b/src/dispatcher/StorefrontDispatcher.js
@@ -1,5 +1,6 @@
 import Alt from 'alt';
 
 let dispatcher = new Alt();
+Alt.debug('alt', dispatcher);
 
 export default dispatcher;

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import Price from './components/Price';
 import Img from './components/Img';
 import Link from './components/Link';
 import Placeholder from './components/Placeholder';
+import contextify from './utils/contextify';
 
 // Needed for onTouchTap
 // Can go away when react 1.0 release
@@ -34,6 +35,10 @@ const components = [
   },
   {
     name: 'Placeholder@vtex.storefront-sdk',
+    constructor: contextify()(Placeholder)
+  },
+  {
+    name: 'PurePlaceholder@vtex.storefront-sdk',
     constructor: Placeholder
   }
 ];

--- a/src/stores/SettingsStore.js
+++ b/src/stores/SettingsStore.js
@@ -22,14 +22,21 @@ class SettingsStore {
     this.state = getDataFromResources(Immutable.Map(), window.storefront.currentRoute.resources);
   }
 
-  onSaveSettings({id, settings}) {
+  onSaveAreaSettings({id, component, settings}) {
     // Here we are doing an optmistic update. The data is not saved on the
     // server yet, but it probably will.
     this.oldState = this.state;
-    this.setState(this.state.setIn([id, 'settings'], Immutable.Map(settings)));
+
+    const state = this.state.withMutations(state => {
+      state
+       .setIn([id, 'component'], component)
+       .setIn([id, 'settings'], Immutable.Map(settings));
+    });
+
+    this.setState(state);
   }
 
-  onSaveSettingsFail(error) {
+  onSaveAreaSettingsFail(error) {
     // If the server cant update the settings, we go back to the previous state.
     console.warn('Error while saving settings', error);
     this.setState(this.oldState);

--- a/src/utils/contextify.js
+++ b/src/utils/contextify.js
@@ -1,0 +1,49 @@
+import React from 'react';
+
+export default function contextify() {
+  return Component => {
+    class ContextifiedComponent extends React.Component {
+      static contextTypes = {
+        parentId: React.PropTypes.string
+      }
+
+      static childContextTypes = {
+        parentId: React.PropTypes.string
+      }
+
+      getChildContext() {
+        return { parentId: this.state.fullId };
+      }
+
+      componentWillMount() {
+        this.setState({
+          fullId: this.getPlaceholderId(this.props, this.context)
+        });
+      }
+
+      componentWillReceiveProps(nextProps, nextContext) {
+        this.setState({
+          fullId: this.getPlaceholderId(nextProps, nextContext)
+        });
+      }
+
+      getPlaceholderId = (props, context) => {
+        let id = props.id;
+
+        if (context.parentId) {
+          id = context.parentId + '/' + id;
+        }
+
+        return id;
+      }
+
+      render() {
+        return (
+          <Component {...this.props} id={this.state.fullId} />
+        );
+      }
+    }
+
+    return ContextifiedComponent;
+  };
+}

--- a/src/utils/loadPage.js
+++ b/src/utils/loadPage.js
@@ -80,7 +80,7 @@ function getRouteAssets(dispatcher, ignoreAssetLoad) {
   }
 }
 
-export default function loadPage(currentURL, dispatcher, ignoreAssetLoad = false) {
+function loadPage(currentURL, dispatcher, ignoreAssetLoad = false) {
   // Listener of the context store
   const contextListener = () => {
     getRouteAssets(dispatcher, ignoreAssetLoad);
@@ -93,3 +93,4 @@ export default function loadPage(currentURL, dispatcher, ignoreAssetLoad = false
   dispatcher.actions.AreaActions.getRouteResources(currentURL);
 }
 
+export { loadScript, loadPage };


### PR DESCRIPTION
This PR decouples some stuff (like context and the Placeholder) and expose others (Lock route option on Root, contextify, loadPage and loadScript).

Also there's a fix for the SettingsStore, the name between the actions and the listeners were wrong.

For big bonus, there's a simple one line addition that makes possible to use Alt Dev Tools for debugging :smiley: 