### PR TITLE
Add handling for transition edge cases

### DIFF
--- a/src/StorefrontSDK.js
+++ b/src/StorefrontSDK.js
@@ -41,8 +41,27 @@ class StorefrontSDK {
   contextify = contextify
 
   init = () => {
+    // Set isFirstLoad out to be wrapped on the closure
+    let isFirstLoad = true;
     // Set history listener for navigation
     history.listen(location => {
+      // This if/else handles the edge cases of person
+      // clicking like an absolute madman to go to a URL or
+      // clicking on a link that points to the same path
+      if (!isFirstLoad) {
+        const ContextStore = dispatcher.stores.ContextStore.getState();
+        const previousLocation = ContextStore.get('location');
+        const previousURL = previousLocation.pathname + previousLocation.search;
+        const newURL = location.pathname + location.search;
+        const isURLEqual = previousURL === newURL;
+
+        if (ContextStore.get('loading') || isURLEqual) {
+          return false;
+        }
+      } else {
+        isFirstLoad = false;
+      }
+
       // Signal that we are loading the page
       dispatcher.actions.ContextActions.setLoading(true);
       // Start the route loading cycle!


### PR DESCRIPTION
This PR handles the following cases when transitioning a page:
- User clicking like a madman while the page is still loading
- User clicking on a Link that points to the same path that he's currently on