### PR TITLE
Implement userLoggedIn state inside ContextStore

### DIFF
--- a/src/actions/ContextActions.js
+++ b/src/actions/ContextActions.js
@@ -10,6 +10,10 @@ class ContextActions {
   replaceWithCache(URL) {
     return URL;
   }
+
+  setUserLogin(bool) {
+    return bool;
+  }
 }
 
 export default ContextActions;

--- a/src/stores/ContextStore.js
+++ b/src/stores/ContextStore.js
@@ -11,6 +11,8 @@ class ContextStore {
     this.bindActions(dispatcher.actions.AreaActions);
 
     window._storefront.context.token = ('; ' + document.cookie).split('; VtexIdclientAutCookie=').pop().split(';').shift();
+    const cookieName = new RegExp('VtexIdclientAutCookie_' + window._storefront.context.accountName);
+    const userLoggedIn = cookieName.test(document.cookie);
 
     this.state = Immutable.fromJS({ ...window._storefront.context })
       .withMutations(state => {
@@ -19,6 +21,7 @@ class ContextStore {
           .set('params', window.storefront.currentRoute.params)
           .set('location', history.createLocation(currentURL))
           .set('loading', false)
+          .set('userLoggedIn', userLoggedIn)
           .set('_cache', Immutable.Map());
       });
   }
@@ -54,6 +57,10 @@ class ContextStore {
 
   onSetLoading(bool) {
     this.setState(this.state.set('loading', bool));
+  }
+
+  onSetUserLogin(bool) {
+    this.setState(this.state.set('userLoggedIn', bool));
   }
 
   replaceWithCache(URL) {


### PR DESCRIPTION
To better use the login state of the user across different components outside Login (like the ones inside My Orders) this PR implements the state and one action to modify it.